### PR TITLE
Fix php warning "PHP Notice:  Trying to get property of non-object".

### DIFF
--- a/wp-lightbox-2.php
+++ b/wp-lightbox-2.php
@@ -152,7 +152,7 @@ function jqlb_lightbox_comment($comment){
 function jqlb_autoexpand_rel_wlightbox($content) {
 	if(get_option('jqlb_automate') == 1){
 		global $post;	
-		$id = ($post->ID) ? $post->ID : -1;
+		$id = isset($post->ID) ? $post->ID : -1;
 		$content = jqlb_do_regexp($content, $id);
 	}			
 	return $content;


### PR DESCRIPTION
Fix php warning "PHP Notice:  Trying to get property of non-object".